### PR TITLE
feat(FilterSidePanel): Create FilterSidePanel for catalog-view-extensions

### DIFF
--- a/packages/patternfly-4/react-catalog-view-extension/sass/react-catalog-view-extension/_filter-side-panel.scss
+++ b/packages/patternfly-4/react-catalog-view-extension/sass/react-catalog-view-extension/_filter-side-panel.scss
@@ -1,0 +1,50 @@
+.filter-panel-pf {
+  margin: 0 0 30px;
+  padding: 0 15px;
+}
+
+.filter-panel-pf-category {
+  margin-top: 20px;
+
+  &:first-of-type {
+    margin-top: 0;
+  }
+}
+
+.filter-panel-pf-category-title {
+  border: 0;
+  font-size: inherit;
+  margin: 0;
+  font-weight: 700;
+}
+
+.filter-panel-pf-category-items {
+  margin-top: 0;
+  margin-bottom: 0;
+
+  .pf-c-button.pf-m-link {
+    padding: 0;
+  }
+}
+
+.filter-panel-pf-category-item {
+  font-weight: 400;
+  margin-bottom: 0;
+  margin-top: 5px;
+
+  &:first-of-type {
+    margin-top: 0;
+  }
+
+  .checkbox {
+    margin: 0;
+  }
+
+  .item-icon {
+    padding-right: 3px;
+  }
+
+  .item-count {
+    padding-left: 3px;
+  }
+}

--- a/packages/patternfly-4/react-catalog-view-extension/sass/react-catalog-view-extension/_react-catalog-view-extension.scss
+++ b/packages/patternfly-4/react-catalog-view-extension/sass/react-catalog-view-extension/_react-catalog-view-extension.scss
@@ -6,3 +6,4 @@
 @import 'catalog-tile';
 @import 'vertical-tabs';
 @import 'properties-side-panel';
+@import 'filter-side-panel';

--- a/packages/patternfly-4/react-catalog-view-extension/src/components/FilterSidePanel/FilterSidePanel.tsx
+++ b/packages/patternfly-4/react-catalog-view-extension/src/components/FilterSidePanel/FilterSidePanel.tsx
@@ -1,0 +1,24 @@
+import * as React from 'react';
+import classNames from 'classnames';
+
+export interface FilterSidePanelProps extends React.HTMLProps<HTMLDivElement> {
+  /** Children nodes */
+  children: React.ReactNode;
+  /** Additional css classes for the Filter Side Panel */
+  className?: string;
+}
+
+export const FilterSidePanel: React.FunctionComponent<FilterSidePanelProps> = ({
+  children = null,
+  className = '',
+  ...props
+}: FilterSidePanelProps) => {
+  const classes = classNames('filter-panel-pf', className);
+  return (
+    <div className={classes} {...props}>
+      {children}
+    </div>
+  );
+};
+
+export default FilterSidePanel;

--- a/packages/patternfly-4/react-catalog-view-extension/src/components/FilterSidePanel/FilterSidePanelCategory.tsx
+++ b/packages/patternfly-4/react-catalog-view-extension/src/components/FilterSidePanel/FilterSidePanelCategory.tsx
@@ -1,0 +1,81 @@
+import * as React from 'react';
+import classNames from 'classnames';
+import { Button } from '@patternfly/react-core';
+import { default as formStyles } from '@patternfly/react-styles/css/components/Form/form';
+import { css } from '@patternfly/react-styles';
+
+import { childrenToArray } from '../../helpers/util';
+import { Omit } from '../../helpers/typeUtils';
+
+export interface FilterSidePanelCategoryProps extends Omit<React.HTMLProps<HTMLFormElement>, 'title'> {
+  /** Children nodes */
+  children?: React.ReactNode;
+  /** Additional css classes for the Filter Side Panel Category */
+  className?: string;
+  /** Title for the category */
+  title?: string | React.ReactNode;
+  /** Number of items (max) to show before adding Show More link button */
+  maxShowCount?: number;
+  /** Leeway to add to maxShowCount, minimum X for the 'Show X more' */
+  leeway?: number;
+  /** Flag to show all items (ie. set to true after Show X more link is clicked) */
+  showAll?: boolean;
+  /** Callback function when the Show/Hide link button is clicked */
+  onShowAllToggle?: (event: React.SyntheticEvent<HTMLElement>) => void;
+  /** Text for the link to show all items, default 'Show <x> more' */
+  showText?: string;
+  /** Text for the link to hide overflow items, default 'Show less' */
+  hideText?: string;
+}
+
+export const FilterSidePanelCategory: React.FunctionComponent<FilterSidePanelCategoryProps> = ({
+  children = null,
+  className = '',
+  title = null,
+  maxShowCount = 5,
+  leeway = 2,
+  showAll = false,
+  onShowAllToggle = () => null,
+  showText = null,
+  hideText = null,
+  ...props
+}: FilterSidePanelCategoryProps) => {
+  const classes = classNames('filter-panel-pf-category', className);
+  const childrenArray = childrenToArray(children);
+  const itemCount = childrenArray.length;
+  const hiddenCount = itemCount - maxShowCount;
+  let shownChildren;
+  let showAllToggle = null;
+
+  if (hiddenCount <= leeway || showAll) {
+    shownChildren = children;
+    if (hiddenCount > leeway) {
+      showAllToggle = (
+        <Button variant="link" onClick={onShowAllToggle}>
+          {hideText || 'Show less'}
+        </Button>
+      );
+    }
+  } else {
+    shownChildren = childrenArray.slice(0, maxShowCount);
+    if (hiddenCount > leeway) {
+      showAllToggle = (
+        <Button variant="link" onClick={onShowAllToggle}>
+          {showText || `Show ${hiddenCount} more`}
+        </Button>
+      );
+    }
+  }
+
+  return (
+    <form className={classes} {...props}>
+      <fieldset className={`${css(formStyles.formFieldset)} checkbox filter-panel-pf-category-items`}>
+        {title && <legend className="filter-panel-pf-category-title">{title}</legend>}
+        {shownChildren}
+        {showAllToggle}
+      </fieldset>
+    </form>
+  );
+};
+
+export default FilterSidePanelCategory;

--- a/packages/patternfly-4/react-catalog-view-extension/src/components/FilterSidePanel/FilterSidePanelCategoryItem.tsx
+++ b/packages/patternfly-4/react-catalog-view-extension/src/components/FilterSidePanel/FilterSidePanelCategoryItem.tsx
@@ -1,0 +1,45 @@
+import * as React from 'react';
+import classNames from 'classnames';
+import { Checkbox } from '@patternfly/react-core';
+
+import { getUniqueId } from '../../helpers/util';
+
+export interface FilterSidePanelCategoryItemProps extends React.HTMLProps<HTMLElement> {
+  /** Children nodes */
+  children?: React.ReactNode;
+  /** Additional css classes for the Filter Panel Property Item */
+  className?: string;
+  /** Optional icon (or other) to show before the children */
+  icon?: React.ReactNode;
+  /** Optional count of the items matching the filter */
+  count?: number;
+  /** Callback for a click on the Filter Item Checkbox */
+  onClick?: (event: React.SyntheticEvent<HTMLElement>) => void;
+  /** Flag to show if the Filter Item Checkbox is checked. */
+  checked?: boolean;
+}
+
+export const FilterSidePanelCategoryItem: React.FunctionComponent<FilterSidePanelCategoryItemProps> = ({
+  children = null,
+  className = '',
+  icon = null,
+  count = null,
+  onClick = null,
+  checked = false
+}: FilterSidePanelCategoryItemProps) => {
+  const classes = classNames('filter-panel-pf-category-item', className);
+  const label = (
+    <React.Fragment>
+      {icon && <span className="item-icon">{icon}</span>}
+      {children}
+      {Number.isInteger(count) && <span className="item-count">{`(${count})`}</span>}
+    </React.Fragment>
+  );
+  return (
+    <div className={classes}>
+      <Checkbox onClick={onClick} checked={checked} id={getUniqueId()} label={label} />
+    </div>
+  );
+};
+
+export default FilterSidePanelCategoryItem;

--- a/packages/patternfly-4/react-catalog-view-extension/src/components/FilterSidePanel/examples/FilterSidePanel.md
+++ b/packages/patternfly-4/react-catalog-view-extension/src/components/FilterSidePanel/examples/FilterSidePanel.md
@@ -1,0 +1,416 @@
+---
+title: 'Filter side panel'
+section: 'catalog view'
+typescript: true
+propComponents: ['FilterSidePanel', 'FilterSidePanelCategory', 'FilterSidePanelCategoryItem']
+---
+
+import { FilterSidePanel, FilterSidePanelCategory, FilterSidePanelCategoryItem } from '@patternfly/react-catalog-view-extension';
+import { StarIcon, CcPaypalIcon, CcAmexIcon, CcDiscoverIcon, CcVisaIcon, CcMastercardIcon, CcDinersClubIcon } from '@patternfly/react-icons';
+import { TextInput } from '@patternfly/react-core';
+
+import './filterSidePanel.css';
+
+## Introduction
+Note: FilterSidePanel lives in its own package at [`@patternfly/react-catalog-view-extension`](https://www.npmjs.com/package/@patternfly/react-catalog-view-extension)!
+
+Note: the width, border, and top padding styling are not part of the FilterSidePanel.
+
+This package is currently an extension. Extension components do not undergo the same rigorous design or coding review process as core PatternFly components. If enough members of the community find them useful, we will work to move them into our core PatternFly system by starting the design process for the idea.
+
+
+## Examples
+
+```js title=Basic
+import React from 'react';
+import { FilterSidePanel, FilterSidePanelCategory, FilterSidePanelCategoryItem } from '@patternfly/react-catalog-view-extension';
+import { StarIcon, CcPaypalIcon, CcAmexIcon, CcDiscoverIcon, CcVisaIcon, CcMastercardIcon, CcDinersClubIcon } from '@patternfly/react-icons';
+import { TextInput } from '@patternfly/react-core';
+
+class MockFilterSidePanelExample extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      activeFilters: {
+        typeSUV: false,
+        typeSedan: false,
+        typePickup: false,
+        typeSports: false,
+        makeChevy: false,
+        makeFord: false,
+        makeDodge: false,
+        makeVolkswagen: false,
+        makeHyundai: false,
+        makeHonda: false,
+        makeToyota: false,
+        makeMercedes: false,
+        makeBMW: false,
+        makeInfiniti: false,
+        makeLexus: false,
+        makeAcura: false,
+        paymentPaypal: false,
+        paymentDiscover: false,
+        paymentVisa: false,
+        paymentMastercard: false,
+        paymentAmex: false,
+        paymentDinersClub: false,
+        mileage50: false,
+        mileage40: false,
+        mileage30: false,
+        mileage20: false,
+        mileage10: false,
+        rating5: false,
+        rating4: false,
+        rating3: false,
+        rating2: false,
+        rating1: false
+      },
+      showAllCategories: {
+        type: false,
+        make: false,
+        paymentOptions: false,
+        mileage: false,
+        rating: false
+      }
+    };
+    
+    this.onShowAllToggle = id => {
+      const showAllCategories = { ...this.state.showAllCategories };
+      showAllCategories[id] = !showAllCategories[id];
+      this.setState({ showAllCategories });
+    };
+  
+    this.onFilterChange = (id, value) => {
+      const activeFilters = { ...this.state.activeFilters };
+      activeFilters[id] = value;
+      this.setState({ activeFilters });
+    };
+  
+    this.getStars = count => {
+      const stars = [];
+  
+      for (let i = 0; i < count; i++) {
+        stars.push(<StarIcon key={i} />);
+      }
+  
+      return (
+        <span>
+          <span className="sr-only">{`${count} stars`}</span>
+          {stars}
+        </span>
+      );
+    };
+  }
+  
+  render() {
+    const { activeFilters, showAllCategories } = this.state;
+    const maxShowCount = 5;
+    const leeway = 2;
+    return (
+     <div style={{ width: '205px', border: '1px solid grey', paddingTop: '20px' }}>   
+      <FilterSidePanel id="filter-panel">
+        <FilterSidePanelCategory key="cat1"> 
+          <TextInput type="text" id="filter-text-input" placeholder="Filter by name" />
+        </FilterSidePanelCategory>
+        <FilterSidePanelCategory
+          key="cat2"
+          title="Type"
+          maxShowCount={maxShowCount}
+          leeway={leeway}
+          showAll={showAllCategories.type}
+          onShowAllToggle={() => this.onShowAllToggle('type')}
+        >
+          <FilterSidePanelCategoryItem
+            key="suv"
+            count={23}
+            checked={activeFilters.typeSUV}
+            onClick={e => this.onFilterChange('typeSUV', e.target.checked)}
+          >
+            SUV
+          </FilterSidePanelCategoryItem>
+          <FilterSidePanelCategoryItem
+            key="sedan"
+            count={11}
+            checked={activeFilters.typeSedan}
+            onClick={e => this.onFilterChange('typeSedan', e.target.checked)}
+          >
+            Sedan
+          </FilterSidePanelCategoryItem>
+          <FilterSidePanelCategoryItem
+            key="pickup"
+            count={5}
+            checked={activeFilters.typePickup}
+            onClick={e => this.onFilterChange('typePickup', e.target.checked)}
+          >
+            Pickup Truck
+          </FilterSidePanelCategoryItem>
+          <FilterSidePanelCategoryItem
+            key="sports"
+            count={3}
+            checked={activeFilters.typeSports}
+            onClick={e => this.onFilterChange('typeSports', e.target.checked)}
+          >
+            Sports Car
+          </FilterSidePanelCategoryItem>
+        </FilterSidePanelCategory>
+        <FilterSidePanelCategory
+          key="cat3"
+          title="Manufacturer"
+          maxShowCount={maxShowCount}
+          leeway={leeway}
+          showAll={showAllCategories.manufacturer}
+          onShowAllToggle={() => this.onShowAllToggle('manufacturer')}
+        >
+          <FilterSidePanelCategoryItem
+            key="chevy"
+            count={6}
+            checked={activeFilters.makeChevy}
+            onClick={e => this.onFilterChange('makeChevy', e.target.checked)}
+          >
+            Chevrolet
+          </FilterSidePanelCategoryItem>
+          <FilterSidePanelCategoryItem
+            key="ford"
+            count={5}
+            checked={activeFilters.makeFord}
+            onClick={e => this.onFilterChange('makeFord', e.target.checked)}
+          >
+            Ford
+          </FilterSidePanelCategoryItem>
+          <FilterSidePanelCategoryItem
+            key="dodge"
+            count={7}
+            checked={activeFilters.makeDodge}
+            onClick={e => this.onFilterChange('makeDodge', e.target.checked)}
+          >
+            Dodge
+          </FilterSidePanelCategoryItem>
+          <FilterSidePanelCategoryItem
+            key="volks"
+            count={4}
+            checked={activeFilters.makeVolkswagen}
+            onClick={e => this.onFilterChange('makeVolkswagen', e.target.checked)}
+          >
+            Volkswagen
+          </FilterSidePanelCategoryItem>
+          <FilterSidePanelCategoryItem
+            key="hyundai"
+            count={2}
+            checked={activeFilters.makeHyundai}
+            onClick={e => this.onFilterChange('makeHyundai', e.target.checked)}
+          >
+            Hyundai
+          </FilterSidePanelCategoryItem>
+          <FilterSidePanelCategoryItem
+            key="honda"
+            count={3}
+            checked={activeFilters.makeHonda}
+            onClick={e => this.onFilterChange('makeHonda', e.target.checked)}
+          >
+            Honda
+          </FilterSidePanelCategoryItem>
+          <FilterSidePanelCategoryItem
+            key="toyota"
+            count={6}
+            checked={activeFilters.makeToyota}
+            onClick={e => this.onFilterChange('makeToyota', e.target.checked)}
+          >
+            Toyota
+          </FilterSidePanelCategoryItem>
+          <FilterSidePanelCategoryItem
+            key="mercedes"
+            count={2}
+            checked={activeFilters.makeMercedes}
+            onClick={e => this.onFilterChange('makeMercedes', e.target.checked)}
+          >
+            Mercedes
+          </FilterSidePanelCategoryItem>
+          <FilterSidePanelCategoryItem
+            key="bmw"
+            count={2}
+            checked={activeFilters.makeBMW}
+            onClick={e => this.onFilterChange('makeBMW', e.target.checked)}
+          >
+            BMW
+          </FilterSidePanelCategoryItem>
+          <FilterSidePanelCategoryItem
+            key="infiniti"
+            count={1}
+            checked={activeFilters.makeInfiniti}
+            onClick={e => this.onFilterChange('makeInfiniti', e.target.checked)}
+          >
+            Infiniti
+          </FilterSidePanelCategoryItem>
+          <FilterSidePanelCategoryItem
+            key="lexus"
+            count={1}
+            checked={activeFilters.makeLexus}
+            onClick={e => this.onFilterChange('makeLexus', e.target.checked)}
+          >
+            Lexus
+          </FilterSidePanelCategoryItem>
+          <FilterSidePanelCategoryItem
+            key="acura"
+            count={0}
+            checked={activeFilters.makeAcura}
+            onClick={e => this.onFilterChange('makeAcura', e.target.checked)}
+          >
+            Acura
+          </FilterSidePanelCategoryItem>
+        </FilterSidePanelCategory>
+        <FilterSidePanelCategory
+          key="cat4"
+          title="Payment Options"
+          maxShowCount={maxShowCount}
+          leeway={leeway}
+          showAll={showAllCategories.payment}
+          onShowAllToggle={() => this.onShowAllToggle('payment')}
+        >
+          <FilterSidePanelCategoryItem
+            key="pp"
+            icon={<CcPaypalIcon />}
+            checked={activeFilters.paymentPaypal}
+            onClick={e => this.onFilterChange('paymentPaypal', e.target.checked)}
+          >
+            PayPal
+          </FilterSidePanelCategoryItem>
+          <FilterSidePanelCategoryItem
+            key="discover"
+            icon={<CcDiscoverIcon />}
+            checked={activeFilters.paymentDiscover}
+            onClick={e => this.onFilterChange('paymentDiscover', e.target.checked)}
+          >
+            Discover
+          </FilterSidePanelCategoryItem>
+          <FilterSidePanelCategoryItem
+            key="visa"
+            icon={<CcVisaIcon />}
+            checked={activeFilters.paymentVisa}
+            onClick={e => this.onFilterChange('paymentVisa', e.target.checked)}
+          >
+            Visa
+          </FilterSidePanelCategoryItem>
+          <FilterSidePanelCategoryItem
+            key="mc"
+            icon={<CcMastercardIcon />}
+            checked={activeFilters.paymentMastercard}
+            onClick={e => this.onFilterChange('paymentMastercard', e.target.checked)}
+          >
+            Mastercard
+          </FilterSidePanelCategoryItem>
+          <FilterSidePanelCategoryItem
+            key="amex"
+            icon={<CcAmexIcon />}
+            checked={activeFilters.paymentAmex}
+            onClick={e => this.onFilterChange('paymentAmex', e.target.checked)}
+          >
+            American Express
+          </FilterSidePanelCategoryItem>
+          <FilterSidePanelCategoryItem
+            key="dc"
+            icon={<CcDinersClubIcon />}
+            checked={activeFilters.paymentDinersClub}
+            onClick={e => this.onFilterChange('paymentDinersClub', e.target.checked)}
+          >
+            {"Diner's Club"}
+          </FilterSidePanelCategoryItem>
+        </FilterSidePanelCategory>
+        <FilterSidePanelCategory
+          key="cat5"
+          title="Fuel Mileage"
+          maxShowCount={maxShowCount}
+          leeway={leeway}
+          showAll={showAllCategories.mileage}
+          onShowAllToggle={() => this.onShowAllToggle('mileage')}
+        >
+          <FilterSidePanelCategoryItem
+            key="gt50"
+            count={3}
+            checked={activeFilters.mileage50}
+            onClick={e => this.onFilterChange('mileage50', e.target.checked)}
+          >
+            50+
+          </FilterSidePanelCategoryItem>
+          <FilterSidePanelCategoryItem
+            key="4050"
+            count={7}
+            checked={activeFilters.mileage40}
+            onClick={e => this.onFilterChange('mileage40', e.target.checked)}
+          >
+            40-50
+          </FilterSidePanelCategoryItem>
+          <FilterSidePanelCategoryItem
+            key="3040"
+            count={9}
+            checked={activeFilters.mileage30}
+            onClick={e => this.onFilterChange('mileage30', e.target.checked)}
+          >
+            30-40
+          </FilterSidePanelCategoryItem>
+          <FilterSidePanelCategoryItem
+            key="2030"
+            count={12}
+            checked={activeFilters.mileage20}
+            onClick={e => this.onFilterChange('mileage20', e.target.checked)}
+          >
+            20-30
+          </FilterSidePanelCategoryItem>
+          <FilterSidePanelCategoryItem
+            key="gt20"
+            count={8}
+            checked={activeFilters.mileage10}
+            onClick={e => this.onFilterChange('mileage10', e.target.checked)}
+          >
+            {'< 20'}
+          </FilterSidePanelCategoryItem>
+        </FilterSidePanelCategory>
+        <FilterSidePanelCategory
+          key="cat6"
+          title="Rating"
+          maxShowCount={maxShowCount}
+          leeway={leeway}
+          showAll={showAllCategories.rating}
+          onShowAllToggle={() => this.onShowAllToggle('rating')}
+        >
+          <FilterSidePanelCategoryItem
+            key="5star"
+            count={2}
+            icon={this.getStars(5)}
+            checked={activeFilters.rating5}
+            onClick={e => this.onFilterChange('rating5', e.target.checked)}
+          />
+          <FilterSidePanelCategoryItem
+            key="4star"
+            count={12}
+            icon={this.getStars(4)}
+            checked={activeFilters.rating4}
+            onClick={e => this.onFilterChange('rating4', e.target.checked)}
+          />
+          <FilterSidePanelCategoryItem
+            key="3star"
+            count={8}
+            icon={this.getStars(3)}
+            checked={activeFilters.rating3}
+            onClick={e => this.onFilterChange('rating3', e.target.checked)}
+          />
+          <FilterSidePanelCategoryItem
+            key="2star"
+            count={5}
+            icon={this.getStars(2)}
+            checked={activeFilters.rating2}
+            onClick={e => this.onFilterChange('rating2', e.target.checked)}
+          />
+          <FilterSidePanelCategoryItem
+            key="1star"
+            count={3}
+            icon={this.getStars(1)}
+            checked={activeFilters.rating1}
+            onClick={e => this.onFilterChange('rating1', e.target.checked)}
+          />
+        </FilterSidePanelCategory>
+      </FilterSidePanel>
+    </div>
+    );
+  }
+}
+```

--- a/packages/patternfly-4/react-catalog-view-extension/src/components/FilterSidePanel/examples/filterSidePanel.css
+++ b/packages/patternfly-4/react-catalog-view-extension/src/components/FilterSidePanel/examples/filterSidePanel.css
@@ -1,0 +1,50 @@
+.filter-panel-pf {
+  margin: 0 0 30px;
+  padding: 0 15px;
+}
+
+.filter-panel-pf-category {
+  margin-top: 20px;
+}
+
+.filter-panel-pf-category:first-of-type {
+  margin-top: 0;
+}
+
+.filter-panel-pf-category-title {
+  border: 0;
+  font-size: inherit;
+  margin: 0;
+  font-weight: 700;
+}
+
+.filter-panel-pf-category-items {
+  margin-top: 0;
+  margin-bottom: 0;
+}
+
+.filter-panel-pf-category-items .pf-c-button.pf-m-link {
+  padding: 0;
+}
+
+.filter-panel-pf-category-item {
+  font-weight: 400;
+  margin-bottom: 0;
+  margin-top: 5px;
+}
+
+.filter-panel-pf-category-item:first-of-type {
+  margin-top: 0;
+}
+
+.filter-panel-pf-category-item .checkbox {
+  margin: 0;
+}
+
+.filter-panel-pf-category-item .item-icon {
+  padding-right: 3px;
+}
+
+.filter-panel-pf-category-item .item-count {
+  padding-left: 3px;
+}

--- a/packages/patternfly-4/react-catalog-view-extension/src/components/FilterSidePanel/index.ts
+++ b/packages/patternfly-4/react-catalog-view-extension/src/components/FilterSidePanel/index.ts
@@ -1,0 +1,3 @@
+export * from './FilterSidePanelCategoryItem';
+export * from './FilterSidePanel';
+export * from './FilterSidePanelCategory';

--- a/packages/patternfly-4/react-catalog-view-extension/src/components/index.ts
+++ b/packages/patternfly-4/react-catalog-view-extension/src/components/index.ts
@@ -3,3 +3,4 @@ export * from './CatalogItemHeader';
 export * from './CatalogTile';
 export * from './VerticalTabs';
 export * from './PropertiesSidePanel';
+export * from './FilterSidePanel';

--- a/packages/patternfly-4/react-catalog-view-extension/src/helpers/util.test.js
+++ b/packages/patternfly-4/react-catalog-view-extension/src/helpers/util.test.js
@@ -1,0 +1,8 @@
+import React from 'react';
+import {
+  getUniqueId,
+} from './util';
+
+test('getUniqueId', () => {
+  expect(getUniqueId()).not.toBe(getUniqueId());
+});

--- a/packages/patternfly-4/react-catalog-view-extension/src/helpers/util.ts
+++ b/packages/patternfly-4/react-catalog-view-extension/src/helpers/util.ts
@@ -1,0 +1,14 @@
+import * as React from 'react';
+
+export function getUniqueId(prefix = 'pf') {
+  const uid =
+    new Date().getTime() +
+    Math.random()
+      .toString(36)
+      .slice(2);
+  return `${prefix}-${uid}`;
+}
+
+/** Returns the given React children prop as a regular array of React nodes. */
+export const childrenToArray = (children: React.ReactNode) =>
+  children && React.Children.count(children) > 0 && React.Children.toArray(children);


### PR DESCRIPTION

Provide a migration path from pf3-pf4 for FilterSidePanel without changing the API and with minor style changes

re #3159

cc: @rebeccaalpert 

<!--
Thanks for your interest in patternfly-react. We appreciate all issues filed and PRs submitted!

Please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->



<!-- feel free to add additional comments -->

![Screen Shot 2019-10-23 at 5 39 15 PM](https://user-images.githubusercontent.com/35978579/67436318-1797ec80-f5bc-11e9-9ae0-fe3c74447d70.png)
